### PR TITLE
Disable update on main for orchestra

### DIFF
--- a/workflow-templates/conductor-on-orchestra.yaml
+++ b/workflow-templates/conductor-on-orchestra.yaml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - "sandbox-*"
-      - "main"
 
 jobs:
   conductor:


### PR DESCRIPTION
All repos that needs this feature should already be updated, ad-hoc sandboxes should not update on main as they're not the primary services that directly support reverb.com. ( at least for now )